### PR TITLE
Fix bug with keyframe conversion

### DIFF
--- a/0 - AE - Prepare For Render.jsx
+++ b/0 - AE - Prepare For Render.jsx
@@ -54,7 +54,7 @@ if(proj) {
                 while(propertyGroups.length > 0) {
                     var group = propertyGroups.pop();
                     
-                    for(var k = 1; k < group.numProperties; k++) {
+                    for(var k = 1; k <= group.numProperties; k++) {
                         var prop = group.property(k);
 
                         if(prop.canSetExpression && prop.expressionEnabled) {


### PR DESCRIPTION
The last property in the layer was not being converted to keyframes due to wrong bounds check